### PR TITLE
fix usage example

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -74,7 +74,7 @@ pg_version    8 or 9
 == Usage
 
   # Add to your crontab or whatever
-  rake db2fog:full
+  rake db2fog:backup
 
   # Handy tasks
   rake db2fog:restore  # You should be testing this regularly


### PR DESCRIPTION
the db2fog:backup:full rake task is deprecated, use db2fog:backup instead
